### PR TITLE
Add support for scrolling inside a parent element

### DIFF
--- a/ValidationContext.jsx
+++ b/ValidationContext.jsx
@@ -65,14 +65,14 @@ class ValidationProvider extends Component {
     });
   }
 
-  validate = (state, schema, scrollToErrors) => {
+  validate = (state, schema, scrollToErrors, scrollableParentRef) => {
     try {
       schema.validateSync(state, { abortEarly: false });
     } catch (errors) {
       const formattedErrors = ValidationProvider.buildErrors(errors);
       this.setErrors(formattedErrors);
       if (scrollToErrors) {
-        this.scrollToError(formattedErrors);
+        this.scrollToError(formattedErrors, scrollableParentRef);
       }
       return false;
     }
@@ -88,7 +88,7 @@ class ValidationProvider extends Component {
     this.setState({ formRefs });
   }
 
-  scrollToError = (errors) => {
+  scrollToError = (errors, scrollableParentRef) => {
     if (!errors || Object.keys(errors).length === 0) {
       return;
     }
@@ -96,7 +96,7 @@ class ValidationProvider extends Component {
     const { formRefs } = this.state;
     const firstElementWithErrors = formRefs[Object.keys(errors)[0]];
 
-    scrollToElement(firstElementWithErrors);
+    scrollToElement(firstElementWithErrors, scrollableParentRef);
   }
 
   render() {

--- a/utils.js
+++ b/utils.js
@@ -1,15 +1,28 @@
-export const scrollToElement = (elementRef) => {
+export const scrollToElement = (elementRef, scrollableParentRef) => {
   const elementCheck = setInterval(() => {
     const element = elementRef.current;
-    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
 
-    if (elementRef.current) {
-      window.scrollTo({
-        top: element.getBoundingClientRect().top + scrollTop,
-        left: 0,
-        behavior: 'smooth',
-      });
-      clearInterval(elementCheck);
+    if (scrollableParentRef) {
+      const scrollingElement = scrollableParentRef && scrollableParentRef.current;
+      if (elementRef.current && scrollingElement) {
+        scrollingElement.scrollTo({
+          top: element.getBoundingClientRect().top - scrollingElement.offsetTop,
+          left: 0,
+          behavior: 'smooth',
+        });
+      }
+    } else {
+      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+      if (elementRef.current) {
+        window.scrollTo({
+          top: element.getBoundingClientRect().top + scrollTop,
+          left: 0,
+          behavior: 'smooth',
+        });
+      }
     }
+
+    clearInterval(elementCheck);
   }, 100);
 };
+


### PR DESCRIPTION
This allows scroll to errors inside a configurable parent element.

This is achieved with an additional argument of the validate function that is the ref of the scrollable parent element. This ref is then passed to the scrollToElement utility function, where I have added additional logic to calculate the scroll to position for the parent element.